### PR TITLE
Adding SPDX license info to each file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# NAME: stalld
+#
+# SPDX-License-Identifier: GPL-2.0
 NAME	:=	stalld
 VERSION	:=	1.2
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # stalld
 
+SPDX-License-Identifier: GPL-2.0
+
 The stalld program (which stands for 'stall daemon') is a
 mechanism to prevent the *starvation* of operating system threads in a
 Linux system. The premise is to start up on a *housekeeping* cpu (one

--- a/man/stalld.8
+++ b/man/stalld.8
@@ -1,3 +1,4 @@
+.\" SPDX-License-Identifier: GPL-2.0-or-later
 .TH STALLD 8
 .SH NAME
 stalld \- detect starving threads and boost them

--- a/redhat/Makefile
+++ b/redhat/Makefile
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0
 # Red Hat specific Makefile
 
 HERE	:=	$(shell pwd)

--- a/redhat/stalld.conf
+++ b/redhat/stalld.conf
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0
 #
 # parameters for the stalld service
 #

--- a/redhat/stalld.service
+++ b/redhat/stalld.service
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0
 [Unit]
 Description=Stall Monitor
 

--- a/redhat/stalld.spec
+++ b/redhat/stalld.spec
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: GPL-2.0
 Name:		stalld
 Version:	1.2
 Release:	1%{?dist}

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: GPL-2.0
+#
+# Makefile for test01 - a test for monitoring thread starvation
+#
 CC	:= gcc
 CFLAGS	:= -g -Wall -pthread
 LIBS	:= -lpthread

--- a/tests/test01.c
+++ b/tests/test01.c
@@ -1,6 +1,10 @@
 /*
  * test01 - create a blocker thread and a starving thread and see if
  * 		stalld fixes the issue
+ *
+ * SPDX-License-Identifier: GPL-2.0
+ *
+ * Copyright (C) 2020 Red Hat Inc, Daniel Bristot de Oliveira <bristot@redhat.com>
  */
 #define _GNU_SOURCE
 #include <ctype.h>


### PR DESCRIPTION
Added SPDX license identifiers to files to clearly indicate licensing information in compliance with the project's licensing guidelines.